### PR TITLE
Modifies grid to decouple internal state and DOM update

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -219,7 +219,6 @@ function replaceSimulation() {
     // initialize grid
     genotypeGrid = new hareGrid(simulation, 'genotype-grid');
     graphSetup();
-    genotypeGrid.updateGrid();
     updateWeatherBar();
     updateStatusPanel();
 }
@@ -320,6 +319,7 @@ function main() {
                 simulation.advanceWeek();
                 updateFreqGraphData();
                 updateSnowGraphData();
+                genotypeGrid.doTick();
             }
         } else {
             let numWeeks = advanceRateValue;
@@ -333,6 +333,7 @@ function main() {
                 simulation.advanceWeek();
                 updateFreqGraphData();
                 updateSnowGraphData();
+                genotypeGrid.doTick();
             }
         }
         // update status panel
@@ -534,7 +535,6 @@ function main() {
 
     controlForm.querySelector('#play-rate').addEventListener('input', (e) => {
         playRate = parseInt(e.target.value);
-        console.log(playRate);
         if (currentInterval) {
             clearInterval(currentInterval);
             currentInterval = setInterval(() => runSimulation(e), playRate);

--- a/js/modules/simulation.js
+++ b/js/modules/simulation.js
@@ -138,8 +138,8 @@ export class Simulation {
         this.climateGenerator.advanceWeek();
         this.generationGenerator.advanceWeek();
         this.snowCoverage = this.climateGenerator.getSnowCoverage();
+        this.week++;
         if (this.hares.length === 0) {
-            this.week++;
             return;
         }
         if (this.generationGenerator.shouldGenerate()) {
@@ -153,7 +153,6 @@ export class Simulation {
                 this.week
             );
         });
-        this.week++;
     }
 
     getPossibleCoatAlleles() {


### PR DESCRIPTION
Grid now updates internally along with the simulation when visual updates are not desired so it can be noted if a hare died mismatched on the display in a "time skip."

Fixes #21.